### PR TITLE
redact_priv_msg should only redact private messages

### DIFF
--- a/perl/pushover.pl
+++ b/perl/pushover.pl
@@ -132,7 +132,7 @@ sub print_cb
 
 	my $msg = "[$buffer_full_name] <$prefix> ";
 
-	if ($OPTIONS{redact_priv_msg} eq "on") {
+	if ($buffer_type eq "private" && $OPTIONS{redact_priv_msg} eq "on") {
 		$msg .= "...";
 	} else {
 		$msg .= "$message";


### PR DESCRIPTION
Sorry, missed out an essential piece of logic. Without this test, highlighted messages would also be redacted if `redact_priv_msg` is enabled (regardless of whether `show_priv_msg` is enabled).
